### PR TITLE
Modify customize group files instead of top level

### DIFF
--- a/open-junk-file.el
+++ b/open-junk-file.el
@@ -101,7 +101,7 @@
 (eval-when-compile (require 'cl))
 (defgroup open-junk-file nil
   "open-junk-file"
-  :group 'emacs)
+  :group 'files)
 (defcustom open-junk-file-format "~/junk/%Y/%m/%d-%H%M%S."
   "File format to put junk files with directory.
 It can include `format-time-string' format specifications."


### PR DESCRIPTION
カスタマイズのトップレベルに直接置くことは適切ではないように感じられます。

## Before

<img width="532" alt="2016-12-10 13 46 38" src="https://cloud.githubusercontent.com/assets/822086/21071279/5b5e0524-bedf-11e6-8440-d859a5fc4679.png">

## After

`'files` のサブカテゴリに置く

<img width="645" alt="2016-12-10 13 47 38" src="https://cloud.githubusercontent.com/assets/822086/21071278/5b5d561a-bedf-11e6-873e-8f826ce7221c.png">

## recentf-ext

[recentf-ext](https://melpa.org/#/recentf-ext)がEmacs Wikiにあるようなのでついでにこちらで報告しますが、こちらも`'recentf`または`'files`のサブカテゴリに置くべきであるように感じます。