### PR TITLE
Prevent errors in find-file-hook--open-junk-file

### DIFF
--- a/open-junk-file.el
+++ b/open-junk-file.el
@@ -119,9 +119,10 @@ Whether the file is a JUNK or not is infered by `open-junk-file-format'.")
 ;;;###autoload
 (defun find-file-hook--open-junk-file ()
   "Run `open-junk-file-hook' when the file is a JUNK file."
-  (when (string-prefix-p
-         (file-truename (replace-regexp-in-string "%.+$" "" open-junk-file-format))
-         (file-truename buffer-file-name))
+  (when (ignore-errors
+          (string-prefix-p
+           (file-truename (replace-regexp-in-string "%.+$" "" open-junk-file-format))
+           (file-truename buffer-file-name)))
     (run-hooks 'open-junk-file-hook)))
 
 ;;;###autoload


### PR DESCRIPTION
`buffer-file-name`はファイルが`find-file`より開いたときもnilにさせられていることがあります。例えば、[nov.el](https://github.com/wasamasa/nov.el)はこうして自動保存を無効にできています(<https://github.com/wasamasa/nov.el/blob/ecbdecc927a3b3f7e0927d225e6e6464c244c2ae/nov.el#L720>)：

```elisp
(define-derived-mode nov-mode special-mode "EPUB"
  ;; 中略 …
  (setq nov-file-name (buffer-file-name))
  (set-visited-file-name nil t) ; disable autosaves and save questions
  ;; …
```

このとき、`find-file-hook--open-junk-file`の`file-truename`からエラーが出てしまいます。

こんなファイルやバッファーがjunk fileであることはないと思うので、エラーが出たら無視してフックも実行しないようにしました。